### PR TITLE
Include missing configuration files in OS X and Linux assemblies

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -75,7 +75,7 @@ should work on most Unix distributions)
 
     UMS.conf
     WEB.conf
-    ffmpeg.webfilters   (used for trailers.apple.com, could be downloaded from https://github.com/UniversalMediaServer/UniversalMediaServer/blob/master/src/main/external-resources/ffmpeg.webfilters)
+    ffmpeg.webfilters
     VirtualFolders.conf
 
 UMS accesses some files in the ums-<version> directory (the working directory).

--- a/src/main/assembly/assembly-linux.xml
+++ b/src/main/assembly/assembly-linux.xml
@@ -89,11 +89,15 @@
 				<include>WEB.conf</include>
 				<include>logback.headless.xml</include>
 				<include>logback.xml</include>
+				<include>documentation/**</include>
 				<include>linux/*.txt</include>
 				<include>plugins/**</include>
 				<include>renderers/*</include>
 				<include>VirtualFolders.conf</include>
 				<include>DummyInput.ass</include>
+				<include>DummyInput.jpg</include>
+				<include>web/**</include>
+				<include>ffmpeg.webfilters</include>
 			</includes>
 		</fileSet>
 

--- a/src/main/assembly/assembly-osx.xml
+++ b/src/main/assembly/assembly-osx.xml
@@ -91,6 +91,7 @@
 				<include>DummyInput.ass</include>
 				<include>DummyInput.jpg</include>
 				<include>web/**</include>
+				<include>ffmpeg.webfilters</include>
 			</includes>
 		</fileSet>
 

--- a/src/main/assembly/assembly-osx_java7_8.xml
+++ b/src/main/assembly/assembly-osx_java7_8.xml
@@ -81,6 +81,7 @@
 				<include>DummyInput.ass</include>
 				<include>DummyInput.jpg</include>
 				<include>web/**</include>
+				<include>ffmpeg.webfilters</include>
 			</includes>
 		</fileSet>
                 


### PR DESCRIPTION
@Sami32 If you merge this into `Patch6` your pull request will include the missing files in the packages for Linux and OS X.

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sami32/universalmediaserver/3)

<!-- Reviewable:end -->
